### PR TITLE
fix(api): disable error log

### DIFF
--- a/packages/api/tests/utils/TestClient.ts
+++ b/packages/api/tests/utils/TestClient.ts
@@ -3,10 +3,11 @@ import request from 'supertest';
 
 import { appImports } from '../../src/App.module';
 import { DatabaseService } from '../../src/Database/Database.service';
-import { User, UserInput, LoginOutput, Path, PathInput } from '../../types';
+import { SeederService } from '../../src/Database/seeders/Seeders.service';
+import { LoginOutput, Path, PathInput, User, UserInput } from '../../types';
 import mutations from './mutations';
 import queries from './queries';
-import { SeederService } from '../../src/Database/seeders/Seeders.service';
+import { TestLogger } from './TestLogger.service';
 
 /**
  * A helper class to test the API
@@ -34,7 +35,9 @@ export abstract class TestClient {
    */
   static async start(resetDatabase = true) {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [...appImports]
+      imports: appImports,
+      providers: [TestLogger],
+      exports: [TestLogger]
     }).compile();
 
     this.db = await moduleFixture.resolve(DatabaseService);
@@ -43,6 +46,7 @@ export abstract class TestClient {
 
 
     this.app = moduleFixture.createNestApplication();
+    this.app.useLogger(this.app.get(TestLogger));
     await this.app.init();
   }
 

--- a/packages/api/tests/utils/TestLogger.service.ts
+++ b/packages/api/tests/utils/TestLogger.service.ts
@@ -1,0 +1,11 @@
+/* eslint-disable no-unused-vars */
+import { Logger } from '@nestjs/common';
+
+/**
+ * Disable logging for tests
+ */
+export class TestLogger extends Logger {
+  error() { /* Disable errors */ }
+
+  log() { /* Disable logging */ }
+}


### PR DESCRIPTION
- Fixes #54 
- Adds a custom logger to disable logging for test

I created the custom logger under utils directory. I'm happy to change the location if needed.