### PR TITLE
fix: createFriendship always from @currentUser

### DIFF
--- a/packages/api/src/Friend/Friend.entity.ts
+++ b/packages/api/src/Friend/Friend.entity.ts
@@ -56,15 +56,6 @@ export class Friend extends CMBaseEntity {
 }
 
 @InputType()
-export class CreateFriendInput {
-  @Field()
-  fromId: string;
-
-  @Field()
-  toId: string;
-}
-
-@InputType()
 export class UpdateFriendInput {
 
   @Field()

--- a/packages/api/src/Friend/Friend.resolver.ts
+++ b/packages/api/src/Friend/Friend.resolver.ts
@@ -5,7 +5,7 @@ import { GQLAuthGuard } from '../Auth/GQLAuth.guard';
 import { FriendService } from './Friend.service';
 import { CurrentUser } from '../User/CurrentUser.decorator';
 import { User } from '../User/User.entity';
-import { Friend, CreateFriendInput, FriendStatus, FriendOutput } from './Friend.entity';
+import { Friend, FriendStatus, FriendOutput } from './Friend.entity';
 
 @Resolver('Friend')
 export class FriendResolver {
@@ -21,8 +21,11 @@ export class FriendResolver {
 
   @UseGuards(GQLAuthGuard)
   @Mutation(() => FriendOutput)
-  createFriendship(@Args('friendInput') friendInput: CreateFriendInput) {
-    return this.friendService.create(friendInput);
+  createFriendship(
+    @CurrentUser() user: User,
+    @Args('toId') toId: string
+  ) {
+    return this.friendService.create(user.id, toId);
   }
 
   @UseGuards(GQLAuthGuard)

--- a/packages/api/src/Friend/Friend.service.ts
+++ b/packages/api/src/Friend/Friend.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
-import { Friend, CreateFriendInput, UpdateFriendInput, FriendOutput } from './Friend.entity';
+import { Friend, UpdateFriendInput, FriendOutput } from './Friend.entity';
 
 @Injectable()
 export class FriendService {
@@ -19,8 +19,7 @@ export class FriendService {
 
   }
 
-  async create(friendInput: CreateFriendInput): Promise<FriendOutput> {
-    const { fromId, toId } = friendInput;
+  async create(fromId: string, toId: string): Promise<FriendOutput> {
     let input = { user1Id: fromId, user2Id: toId };
     // We place the lower id in user1Id
     if (toId < fromId) input = { user1Id: toId, user2Id: fromId };

--- a/packages/api/src/schema.gql
+++ b/packages/api/src/schema.gql
@@ -139,7 +139,7 @@ type Mutation {
   updateConcept(concept: UpdateConceptInput!): Concept!
   deleteConcept(conceptId: String!): Boolean!
   learnConcept(conceptId: String!): Boolean!
-  createFriendship(friendInput: CreateFriendInput!): FriendOutput!
+  createFriendship(toId: String!): FriendOutput!
   respondToFriendRequest(response: String!, user2Id: String!, user1Id: String!): Friend!
   deleteFriendship(friendId: String!): Boolean!
   createModule(module: CreateModuleInput!): Module!
@@ -202,11 +202,6 @@ input UpdateConceptInput {
   icon: String
   description: String
   taughtInId: String
-}
-
-input CreateFriendInput {
-  fromId: String!
-  toId: String!
 }
 
 input CreateModuleInput {

--- a/packages/api/tests/entities/Friends.test.ts
+++ b/packages/api/tests/entities/Friends.test.ts
@@ -20,36 +20,15 @@ describe('Friend entity', () => {
   describe('Mutation: createFriendship', () => {
     beforeEach(setup);
 
-    it('should create friend successfully, case 1: from > to', async () => {
-      let input = { fromId: me.id, toId: user2.id };
-
-      if (me.id < user2.id) {
-        input = { fromId: user2.id, toId: me.id };
-      }
-      const friend = await TestClient.createFriendship(input);
+    it('should create friend successfully', async () => {
+      const toId = user2.id
+      const friend = await TestClient.createFriendship(toId);
 
       expect(friend.id).toBeDefined();
-      expect(friend.user1Id).toEqual(input.toId);
-      expect(friend.user2Id).toEqual(input.fromId);
+      expect(friend.user1Id).toEqual((me.id < user2.id)? me.id: user2.id);
+      expect(friend.user2Id).toEqual((me.id > user2.id)? me.id: user2.id);
       expect(friend.requested).toBeDefined();
-      expect(friend.initiator).toEqual(input.fromId);
-      expect(friend.status).toEqual('pending');
-      expect(friend.since).toBeNull();
-    });
-
-    it('should create friend successfully, case 2: from < to', async () => {
-      let input = { fromId: me.id, toId: user2.id };
-
-      if (me.id > user2.id) {
-        input = { fromId: user2.id, toId: me.id };
-      }
-      const friend = await TestClient.createFriendship(input);
-
-      expect(friend.id).toBeDefined();
-      expect(friend.user1Id).toEqual(input.fromId);
-      expect(friend.user2Id).toEqual(input.toId);
-      expect(friend.requested).toBeDefined();
-      expect(friend.initiator).toEqual(input.fromId);
+      expect(friend.initiator).toEqual(me.id);
       expect(friend.status).toEqual('pending');
       expect(friend.since).toBeNull();
     });
@@ -57,42 +36,14 @@ describe('Friend entity', () => {
     it('should throw error if from and to already exist', async () => {
       expect.assertions(1); // Expect there to be an error
 
-      const input = {
-        fromId: me.id,
-        toId: user2.id
-      };
-
-      await TestClient.createFriendship(input);
+      await TestClient.createFriendship(user2.id);
 
       try {
-        await TestClient.createFriendship(input);
+        await TestClient.createFriendship(user2.id);
       } catch (e) {
         expect(e.message).toContain('UNIQUE constraint failed: friend.user1Id, friend.user2Id');
       }
     });
-
-    it('should throw error when add B and A if A and B are already exist', async () => {
-      expect.assertions(1); // Expect there to be an error
-
-      const input1 = {
-        fromId: me.id,
-        toId: user2.id
-      };
-
-      await TestClient.createFriendship(input1);
-
-      const input2 = {
-        fromId: user2.id,
-        toId: me.id
-      };
-
-      try {
-        await TestClient.createFriendship(input2);
-      } catch (e) {
-        expect(e.message).toContain('UNIQUE constraint failed: friend.user1Id, friend.user2Id');
-      }
-    });
-
   });
 
   describe('Query: getUserFriends', () => {
@@ -103,50 +54,15 @@ describe('Friend entity', () => {
     });
 
     it('should return one friend', async () => {
-      const input = {
-        fromId: me.id,
-        toId: user2.id
-      };
-      const addFriend = await TestClient.createFriendship(input);
+      const addFriend = await TestClient.createFriendship(user2.id);
       const friends = await TestClient.getUserFriends(me.id);
 
       expect(friends[0]).toMatchObject(addFriend);
     });
 
     it('should return two friend', async () => {
-      const input1 = {
-        fromId: me.id,
-        toId: user2.id
-      };
-
-      const input2 = {
-        fromId: user3.id,
-        toId: me.id
-      };
-
-      const addFriend1 = await TestClient.createFriendship(input1);
-      const addFriend2 = await TestClient.createFriendship(input2);
-      const friends = await TestClient.getUserFriends(me.id);
-
-      expect(friends.length).toEqual(2);
-      expect(friends[0]).toMatchObject(addFriend1);
-      expect(friends[1]).toMatchObject(addFriend2);
-    });
-
-    it('should return two friend', async () => {
-      const input1 = {
-        fromId: me.id,
-        toId: user2.id
-      };
-
-      const input2 = {
-        fromId: user3.id,
-        toId: me.id
-      };
-
-      const addFriend1 = await TestClient.createFriendship(input1);
-      const addFriend2 = await TestClient.createFriendship(input2);
-
+      const addFriend1 = await TestClient.createFriendship(user2.id);
+      const addFriend2 = await TestClient.createFriendship(user3.id);
       const friends = await TestClient.getUserFriends(me.id);
 
       expect(friends.length).toEqual(2);
@@ -159,11 +75,7 @@ describe('Friend entity', () => {
     beforeEach(setup);
 
     it('should delete success', async () => {
-      const input = {
-        fromId: me.id,
-        toId: user2.id
-      };
-      await TestClient.createFriendship(input);
+      await TestClient.createFriendship(user2.id);
       const query1 = await TestClient.getUserFriends(me.id);
 
       await TestClient.deleteFriendship(user2.id);
@@ -186,14 +98,9 @@ describe('Friend entity', () => {
     beforeEach(setup);
 
     it('should confirm friend request successfully. case 1: user1Id < user2Id', async () => {
-      const input = {
-        fromId: me.id,
-        toId: user2.id
-      };
-
       const response = 'accepted';
 
-      const request = await TestClient.createFriendship(input);
+      const request = await TestClient.createFriendship(user2.id);
 
       const result = await TestClient.respondToFriendRequest(request.user1Id, request.user2Id, response);
 
@@ -204,14 +111,9 @@ describe('Friend entity', () => {
     });
 
     it('should confirm friend request successfully. case 2: user1Id > user2Id', async () => {
-      const input = {
-        fromId: me.id,
-        toId: user2.id
-      };
-
       const response = 'accepted';
 
-      const request = await TestClient.createFriendship(input);
+      const request = await TestClient.createFriendship(user2.id);
 
       const result = await TestClient.respondToFriendRequest(request.user2Id, request.user1Id, response);
 
@@ -222,14 +124,9 @@ describe('Friend entity', () => {
     });
 
     it('should reject friend request successfully', async () => {
-      const input = {
-        fromId: me.id,
-        toId: user2.id
-      };
-
       const response = 'rejected';
 
-      const request = await TestClient.createFriendship(input);
+      const request = await TestClient.createFriendship(user2.id);
 
       const result = await TestClient.respondToFriendRequest(request.user2Id, request.user1Id, response);
 
@@ -254,12 +151,8 @@ describe('Friend entity', () => {
 
     it('should throw an error if response is not valid value', async () => {
       expect.assertions(1); // Expect there to be an error
-      const input = {
-        fromId: me.id,
-        toId: user2.id
-      };
 
-      const request = await TestClient.createFriendship(input);
+      const request = await TestClient.createFriendship(user2.id);
       const response = 'hmmmm';
 
       try {

--- a/packages/api/tests/utils/TestClient.ts
+++ b/packages/api/tests/utils/TestClient.ts
@@ -14,7 +14,6 @@ import {
   AssignmentFile,
   CreateAssignmentFileInput,
   CreateAssignmentInput,
-  CreateFriendInput,
   CreateModuleInput,
   Friend,
   FriendOutput,
@@ -110,8 +109,8 @@ export abstract class TestClient {
     return this._request('createAssignmentFile', mutations.createAssignmentFile, { assignmentFile });
   }
 
-  static createFriendship(friendInput: CreateFriendInput): Promise<FriendOutput> {
-    return this._request('createFriendship', mutations.createFriendship, { friendInput });
+  static createFriendship(toId: String): Promise<FriendOutput> {
+    return this._request('createFriendship', mutations.createFriendship, { toId });
   }
 
   static respondToFriendRequest(

--- a/packages/api/tests/utils/mutations/createFriendship.gql
+++ b/packages/api/tests/utils/mutations/createFriendship.gql
@@ -1,5 +1,5 @@
-mutation ($friendInput: CreateFriendInput!) {
-  createFriendship( friendInput : $friendInput) {
+mutation ($toId: String!) {
+  createFriendship( toId : $toId) {
     id
     user1Id
     user2Id

--- a/packages/api/types.ts
+++ b/packages/api/types.ts
@@ -138,6 +138,7 @@ export type Query = {
   pathModules: Array<Module>;
   paths: Array<Path>;
   getPathByName: Path;
+  myPaths: Array<Path>;
 };
 
 
@@ -203,6 +204,7 @@ export type Mutation = {
   deleteModule: Scalars['Boolean'];
   createPath: Path;
   joinPath: Scalars['Boolean'];
+  joinPaths: Scalars['Boolean'];
 };
 
 
@@ -212,7 +214,7 @@ export type MutationCreateAssignmentArgs = {
 
 
 export type MutationUpdateAssignmentArgs = {
-  update: UpdateAssignmentInput;
+  assignment: UpdateAssignmentInput;
 };
 
 
@@ -227,7 +229,7 @@ export type MutationCreateAssignmentFileArgs = {
 
 
 export type MutationUpdateAssignmentFileArgs = {
-  update: UpdateAssignmentFileInput;
+  file: UpdateAssignmentFileInput;
 };
 
 
@@ -258,7 +260,7 @@ export type MutationCreateConceptArgs = {
 
 
 export type MutationUpdateConceptArgs = {
-  update: UpdateConceptInput;
+  concept: UpdateConceptInput;
 };
 
 
@@ -273,7 +275,7 @@ export type MutationLearnConceptArgs = {
 
 
 export type MutationCreateFriendshipArgs = {
-  friendInput: CreateFriendInput;
+  toId: Scalars['String'];
 };
 
 
@@ -295,7 +297,7 @@ export type MutationCreateModuleArgs = {
 
 
 export type MutationUpdateModuleArgs = {
-  update: UpdateModuleInput;
+  module: UpdateModuleInput;
 };
 
 
@@ -311,6 +313,11 @@ export type MutationCreatePathArgs = {
 
 export type MutationJoinPathArgs = {
   pathId: Scalars['String'];
+};
+
+
+export type MutationJoinPathsArgs = {
+  paths: Array<Scalars['String']>;
 };
 
 export type CreateAssignmentInput = {
@@ -365,11 +372,6 @@ export type UpdateConceptInput = {
   icon?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   taughtInId?: Maybe<Scalars['String']>;
-};
-
-export type CreateFriendInput = {
-  fromId: Scalars['String'];
-  toId: Scalars['String'];
 };
 
 export type CreateModuleInput = {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Fixed issues (PRs without this will not be accepted)
- Fixes #130 

## Changes
- change createFriendship API param only with toId. since fromId will be always @CurrentUser.
- Friends.test to reflect the change


## PR Checklist
- [ x ] Does your PR contain relevant tests that pass?
- [ x ] Is your code linted? `yarn lint` or `yarn lint:fix`
- [ x ] Does your code build correctly in ALL projects? `yarn build`
