### PR TITLE
Feature/pathlist filter

### DIFF
--- a/packages/api/src/Path/Path.resolver.ts
+++ b/packages/api/src/Path/Path.resolver.ts
@@ -43,6 +43,12 @@ export class PathResolver {
   }
 
   @UseGuards(GQLAuthGuard)
+  @Query(() => [Path])
+  unjoinedPaths(@CurrentUser() user: User) {
+    return this.pathService.findUnjoined(user.id);
+  }
+
+  @UseGuards(GQLAuthGuard)
   @Mutation(() => Boolean)
   async joinPath(
     @Args('pathId') pathId: string,

--- a/packages/api/src/Path/Path.resolver.ts
+++ b/packages/api/src/Path/Path.resolver.ts
@@ -44,8 +44,8 @@ export class PathResolver {
 
   @UseGuards(GQLAuthGuard)
   @Query(() => [Path])
-  unjoinedPaths(@CurrentUser() user: User) {
-    return this.pathService.findUnjoined(user.id);
+  getMyUnjoinedPaths(@CurrentUser() user: User) {
+    return this.pathService.findUnjoinedByUser(user.id);
   }
 
   @UseGuards(GQLAuthGuard)

--- a/packages/api/src/Path/Path.resolver.ts
+++ b/packages/api/src/Path/Path.resolver.ts
@@ -44,7 +44,7 @@ export class PathResolver {
 
   @UseGuards(GQLAuthGuard)
   @Query(() => [Path])
-  getMyUnjoinedPaths(@CurrentUser() user: User) {
+  myUnjoinedPaths(@CurrentUser() user: User) {
     return this.pathService.findUnjoinedByUser(user.id);
   }
 

--- a/packages/api/src/Path/Path.service.ts
+++ b/packages/api/src/Path/Path.service.ts
@@ -36,6 +36,12 @@ export class PathService {
     return userPaths;
   }
 
+  async findUnjoined(userId: string): Promise<Path[]> {
+    const paths = await this.findAll();
+    const joined = await this.findByUser(userId);
+    return paths.filter(p => !joined.map(e => e.id).includes(p.id));
+  }
+
   async create(pathInput: PathInput): Promise<Path> {
     return this.pathRepository.create(pathInput).save();
   }

--- a/packages/api/src/Path/Path.service.ts
+++ b/packages/api/src/Path/Path.service.ts
@@ -36,7 +36,7 @@ export class PathService {
     return userPaths;
   }
 
-  async findUnjoined(userId: string): Promise<Path[]> {
+  async findUnjoinedByUser(userId: string): Promise<Path[]> {
     const paths = await this.findAll();
     const joined = await this.findByUser(userId);
     return paths.filter(p => !joined.map(e => e.id).includes(p.id));

--- a/packages/api/src/Path/Path.service.ts
+++ b/packages/api/src/Path/Path.service.ts
@@ -36,6 +36,7 @@ export class PathService {
     return userPaths;
   }
 
+  // redo this path query
   async findUnjoinedByUser(userId: string): Promise<Path[]> {
     const paths = await this.findAll();
     const joined = await this.findByUser(userId);

--- a/packages/api/src/Path/Path.service.ts
+++ b/packages/api/src/Path/Path.service.ts
@@ -40,7 +40,7 @@ export class PathService {
   async findUnjoinedByUser(userId: string): Promise<Path[]> {
     const paths = await this.findAll();
     const joined = await this.findByUser(userId);
-    return paths.filter(p => !joined.map(e => e.id).includes(p.id));
+    return paths.filter(p => !joined.some(j => p.id === j.pathId));
   }
 
   async create(pathInput: PathInput): Promise<Path> {

--- a/packages/api/src/schema.gql
+++ b/packages/api/src/schema.gql
@@ -152,7 +152,7 @@ type Query {
   path(id: String!): Path!
   getPathByName(name: String!): Path!
   myPaths: [PathUser!]!
-  getMyUnjoinedPaths: [Path!]!
+  myUnjoinedPaths: [Path!]!
 }
 
 type Mutation {

--- a/packages/api/src/schema.gql
+++ b/packages/api/src/schema.gql
@@ -151,7 +151,8 @@ type Query {
   paths: [Path!]!
   path(id: String!): Path!
   getPathByName(name: String!): Path!
-  myPaths: [PathUser!]!
+  myPaths: [Path!]!
+  unjoinedPaths: [Path!]!
 }
 
 type Mutation {

--- a/packages/api/src/schema.gql
+++ b/packages/api/src/schema.gql
@@ -152,7 +152,7 @@ type Query {
   path(id: String!): Path!
   getPathByName(name: String!): Path!
   myPaths: [Path!]!
-  unjoinedPaths: [Path!]!
+  getMyUnjoinedPaths: [Path!]!
 }
 
 type Mutation {

--- a/packages/api/src/schema.gql
+++ b/packages/api/src/schema.gql
@@ -151,7 +151,7 @@ type Query {
   paths: [Path!]!
   path(id: String!): Path!
   getPathByName(name: String!): Path!
-  myPaths: [Path!]!
+  myPaths: [PathUser!]!
   getMyUnjoinedPaths: [Path!]!
 }
 

--- a/packages/api/tests/entities/Path.test.ts
+++ b/packages/api/tests/entities/Path.test.ts
@@ -131,12 +131,12 @@ describe('Path entity', () => {
       const joinPath1 = await TestClient.joinPath(path1.id);
       const joinPath2 = await TestClient.joinPath(path2.id);
 
-      await expect(joinPath1).toBe(true);
-      await expect(joinPath2).toBe(true);
+      expect(joinPath1).toBe(true);
+      expect(joinPath2).toBe(true);
 
       const unjoinedPaths = await TestClient.getMyUnjoinedPaths();
 
-      await expect(unjoinedPaths[0]).toStrictEqual(path3);
+      expect(unjoinedPaths[0]).toStrictEqual(path3);
     });
   });
 });

--- a/packages/api/tests/entities/Path.test.ts
+++ b/packages/api/tests/entities/Path.test.ts
@@ -120,7 +120,7 @@ describe('Path entity', () => {
     });
   });
 
-  describe('Query: getMyUnjoinedPaths', () => {
+  describe('Query: myUnjoinedPaths', () => {
     beforeEach(setup);
 
     it('should return path3', async () => {
@@ -134,7 +134,7 @@ describe('Path entity', () => {
       expect(joinPath1).toBe(true);
       expect(joinPath2).toBe(true);
 
-      const unjoinedPaths = await TestClient.getMyUnjoinedPaths();
+      const unjoinedPaths = await TestClient.myUnjoinedPaths();
 
       expect(unjoinedPaths[0]).toStrictEqual(path3);
     });

--- a/packages/api/tests/entities/Path.test.ts
+++ b/packages/api/tests/entities/Path.test.ts
@@ -1,10 +1,22 @@
 import { PathInput } from '../../types';
 import { TestClient } from '../utils/TestClient';
-import * as random from '../../src/Database/seeders/random'
+import * as random from '../../src/Database/seeders/random';
 
 export const pathInput: PathInput = {
   name: 'Path name',
   icon: 'icon',
+  description: 'Description text'
+};
+
+export const pathInput2: PathInput = {
+  name: 'Path 2',
+  icon: 'icon2',
+  description: 'Description text'
+};
+
+export const pathInput3: PathInput = {
+  name: 'Path 3',
+  icon: 'icon3',
   description: 'Description text'
 };
 
@@ -105,6 +117,26 @@ describe('Path entity', () => {
       const updatePath = await TestClient.getPathByName(path.name);
 
       expect(updatePath.characterId).toEqual(character.id);
+    });
+  });
+
+  describe('Query: getMyUnjoinedPaths', () => {
+    beforeEach(setup);
+
+    it('should return path3', async () => {
+      const path1 = await TestClient.createPath(pathInput);
+      const path2 = await TestClient.createPath(pathInput2);
+      const path3 = await TestClient.createPath(pathInput3);
+
+      const joinPath1 = await TestClient.joinPath(path1.id);
+      const joinPath2 = await TestClient.joinPath(path2.id);
+
+      await expect(joinPath1).toBe(true);
+      await expect(joinPath2).toBe(true);
+
+      const unjoinedPaths = await TestClient.getMyUnjoinedPaths();
+
+      await expect(unjoinedPaths[0]).toStrictEqual(path3);
     });
   });
 });

--- a/packages/api/tests/utils/TestClient.ts
+++ b/packages/api/tests/utils/TestClient.ts
@@ -8,7 +8,10 @@ import { DatabaseService } from '../../src/Database/Database.service';
 import * as random from '../../src/Database/seeders/random';
 import { SeederService } from '../../src/Database/seeders/Seeders.service';
 import { UpdateModuleInput } from '../../src/Module/Module.entity';
-import { UserPreferences, UserPreferencesInput } from '../../src/UserPreferences/UserPreferences.entity';
+import {
+  UserPreferences,
+  UserPreferencesInput,
+} from '../../src/UserPreferences/UserPreferences.entity';
 import {
   Assignment,
   AssignmentFile,
@@ -27,15 +30,17 @@ import {
   Concept,
   CreateConceptInput,
   UserConcept,
-  UpdateConceptInput
+  UpdateConceptInput,
 } from '../../types';
 import mutations from './mutations';
 import queries from './queries';
 import { TestLogger } from './TestLogger.service';
 import { UserWithPassword } from '../../src/User/User.entity';
-import { CreateCharacterInput, UpdateCharacterInput } from '../../src/Character/Character.entity';
+import {
+  CreateCharacterInput,
+  UpdateCharacterInput,
+} from '../../src/Character/Character.entity';
 import { UpdatePathInput } from '../../src/Path/Path.entity';
-
 
 /**
  * A helper class to test the API
@@ -64,7 +69,7 @@ export abstract class TestClient {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: appImports,
       providers: [TestLogger],
-      exports: [TestLogger]
+      exports: [TestLogger],
     }).compile();
 
     this.db = await moduleFixture.resolve(DatabaseService);
@@ -95,7 +100,7 @@ export abstract class TestClient {
   ): Promise<LoginOutput> {
     const res = await this._request<LoginOutput>('login', mutations.login, {
       email,
-      password
+      password,
     });
     if (storeToken) this.token = res.accessToken;
     return res;
@@ -113,28 +118,50 @@ export abstract class TestClient {
     return this._request('updatePath', mutations.updatePath, { path });
   }
 
-  static updatePreferences(preferences: UserPreferencesInput): Promise<UserPreferences> {
-    return this._request('updatePreferences', mutations.updatePreferences, { preferences });
+  static updatePreferences(
+    preferences: UserPreferencesInput
+  ): Promise<UserPreferences> {
+    return this._request('updatePreferences', mutations.updatePreferences, {
+      preferences,
+    });
   }
 
-  static createAssignment(assignment: CreateAssignmentInput): Promise<Assignment> {
-    return this._request('createAssignment', mutations.createAssignment, { assignment });
+  static createAssignment(
+    assignment: CreateAssignmentInput
+  ): Promise<Assignment> {
+    return this._request('createAssignment', mutations.createAssignment, {
+      assignment,
+    });
   }
 
-  static updateAssignment(assignment: UpdateAssignmentInput): Promise<Assignment> {
-    return this._request('updateAssignment', mutations.updateAssignment, { assignment });
+  static updateAssignment(
+    assignment: UpdateAssignmentInput
+  ): Promise<Assignment> {
+    return this._request('updateAssignment', mutations.updateAssignment, {
+      assignment,
+    });
   }
 
   static deleteAssignment(assignmentId: string): Promise<Assignment> {
-    return this._request('deleteAssignment', mutations.deleteAssignment, { assignmentId });
+    return this._request('deleteAssignment', mutations.deleteAssignment, {
+      assignmentId,
+    });
   }
 
-  static createAssignmentFile(assignmentFile: CreateAssignmentFileInput): Promise<AssignmentFile> {
-    return this._request('createAssignmentFile', mutations.createAssignmentFile, { assignmentFile });
+  static createAssignmentFile(
+    assignmentFile: CreateAssignmentFileInput
+  ): Promise<AssignmentFile> {
+    return this._request(
+      'createAssignmentFile',
+      mutations.createAssignmentFile,
+      { assignmentFile }
+    );
   }
 
   static createFriendship(toId: String): Promise<FriendOutput> {
-    return this._request('createFriendship', mutations.createFriendship, { toId });
+    return this._request('createFriendship', mutations.createFriendship, {
+      toId,
+    });
   }
 
   static respondToFriendRequest(
@@ -142,11 +169,17 @@ export abstract class TestClient {
     user2Id: string,
     response: string
   ): Promise<Friend> {
-    return this._request('respondToFriendRequest', mutations.respondToFriendRequest, { user1Id, user2Id, response });
+    return this._request(
+      'respondToFriendRequest',
+      mutations.respondToFriendRequest,
+      { user1Id, user2Id, response }
+    );
   }
 
   static deleteFriendship(friendId: string): Promise<Boolean> {
-    return this._request('deleteFriendship', mutations.deleteFriendship, { friendId });
+    return this._request('deleteFriendship', mutations.deleteFriendship, {
+      friendId,
+    });
   }
 
   static createModule(module: CreateModuleInput): Promise<Module> {
@@ -162,11 +195,15 @@ export abstract class TestClient {
   }
 
   static createCharacter(character: CreateCharacterInput): Promise<Character> {
-    return this._request('createCharacter', mutations.createCharacter, { character });
+    return this._request('createCharacter', mutations.createCharacter, {
+      character,
+    });
   }
 
   static updateCharacter(character: UpdateCharacterInput): Promise<Character> {
-    return this._request('updateCharacter', mutations.updateCharacter, { character });
+    return this._request('updateCharacter', mutations.updateCharacter, {
+      character,
+    });
   }
 
   static deleteCharacter(id: string): Promise<Boolean> {
@@ -178,7 +215,7 @@ export abstract class TestClient {
   }
 
   static learnConcept(conceptId: string): Promise<Boolean> {
-    return this._request('learnConcept', mutations.learnConcept, { conceptId })
+    return this._request('learnConcept', mutations.learnConcept, { conceptId });
   }
 
   static updateConcept(concept: UpdateConceptInput): Promise<Concept> {
@@ -202,7 +239,7 @@ export abstract class TestClient {
     return this._request('modules', queries.modules);
   }
 
-  static getUserFriends(userId: string): Promise< Friend[] > {
+  static getUserFriends(userId: string): Promise<Friend[]> {
     return this._request('getUserFriends', queries.getUserFriends, { userId });
   }
 
@@ -211,16 +248,22 @@ export abstract class TestClient {
   }
 
   static getConceptByName(name: string): Promise<Concept> {
-    return this._request('getConceptByName', queries.getConceptByName, { name });
+    return this._request('getConceptByName', queries.getConceptByName, {
+      name,
+    });
   }
-  
+
   static users(): Promise<User[]> {
     return this._request('users', queries.users);
   }
 
   static getAssignments(): Promise<Assignment[]> {
-      return this._request('assignments', queries.assignments);
-    }
+    return this._request('assignments', queries.assignments);
+  }
+
+  static getMyUnjoinedPaths(): Promise<Path[]> {
+    return this._request('getMyUnjoinedPaths', queries.getMyUnjoinedPaths);
+  }
 
   // ----------------------------------------------------------------- Workflows
   static async workflowSignup() {

--- a/packages/api/tests/utils/TestClient.ts
+++ b/packages/api/tests/utils/TestClient.ts
@@ -261,8 +261,8 @@ export abstract class TestClient {
     return this._request('assignments', queries.assignments);
   }
 
-  static getMyUnjoinedPaths(): Promise<Path[]> {
-    return this._request('getMyUnjoinedPaths', queries.getMyUnjoinedPaths);
+  static myUnjoinedPaths(): Promise<Path[]> {
+    return this._request('myUnjoinedPaths', queries.myUnjoinedPaths);
   }
 
   // ----------------------------------------------------------------- Workflows

--- a/packages/api/tests/utils/queries/getMyUnjoinedPaths.gql
+++ b/packages/api/tests/utils/queries/getMyUnjoinedPaths.gql
@@ -1,0 +1,10 @@
+query getMyUnjoinedPaths {
+  getMyUnjoinedPaths {
+    id
+    name
+    icon
+    description
+    characterId
+    createdAt
+  }
+}

--- a/packages/api/tests/utils/queries/index.ts
+++ b/packages/api/tests/utils/queries/index.ts
@@ -11,7 +11,9 @@ const files = [
   'getUserFriends',
   'getCharacters',
   'assignments',
-  'getConceptByName'
+  'getConceptByName',
+  'getCharacters',
+  'getMyUnjoinedPaths'
 ];
 
 export default files.reduce((obj, file) => {

--- a/packages/api/tests/utils/queries/index.ts
+++ b/packages/api/tests/utils/queries/index.ts
@@ -13,7 +13,7 @@ const files = [
   'assignments',
   'getConceptByName',
   'getCharacters',
-  'getMyUnjoinedPaths'
+  'myUnjoinedPaths'
 ];
 
 export default files.reduce((obj, file) => {

--- a/packages/api/tests/utils/queries/myUnjoinedPaths.gql
+++ b/packages/api/tests/utils/queries/myUnjoinedPaths.gql
@@ -1,5 +1,5 @@
-query getMyUnjoinedPaths {
-  getMyUnjoinedPaths {
+query myUnjoinedPaths {
+  myUnjoinedPaths {
     id
     name
     icon

--- a/packages/client/src/components/PathsList/PathsList.tsx
+++ b/packages/client/src/components/PathsList/PathsList.tsx
@@ -10,7 +10,7 @@ import styles from './PathsList.module.css';
 export type SelectedPath = Pick<Path, 'id'>;
 
 const getPaths = gql`{
-  unjoinedPaths {
+  getMyUnjoinedPaths {
     id
     name
     icon
@@ -30,7 +30,7 @@ export const PathsList: React.FunctionComponent<PathsListProps> = ({
 
   const [selectedPaths, setSelectedPaths] = useState<Path[]>(selected);
   const { data } = useQuery<{ unjoinedPaths: Path[] }>(getPaths);
-  const path = data?.unjoinedPaths;
+  const path = data?.getMyUnjoinedPaths;
 
   useEffect(() => {
     if (onChange) onChange(selectedPaths);

--- a/packages/client/src/components/PathsList/PathsList.tsx
+++ b/packages/client/src/components/PathsList/PathsList.tsx
@@ -10,7 +10,7 @@ import styles from './PathsList.module.css';
 export type SelectedPath = Pick<Path, 'id'>;
 
 const getPaths = gql`{
-  paths {
+  unjoinedPaths {
     id
     name
     icon
@@ -29,8 +29,8 @@ export const PathsList: React.FunctionComponent<PathsListProps> = ({
 }) => {
 
   const [selectedPaths, setSelectedPaths] = useState<Path[]>(selected);
-  const { data } = useQuery<{ paths: Path[] }>(getPaths);
-  const path = data?.paths;
+  const { data } = useQuery<{ unjoinedPaths: Path[] }>(getPaths);
+  const path = data?.unjoinedPaths;
 
   useEffect(() => {
     if (onChange) onChange(selectedPaths);

--- a/packages/client/src/components/PathsList/PathsList.tsx
+++ b/packages/client/src/components/PathsList/PathsList.tsx
@@ -29,7 +29,7 @@ export const PathsList: React.FunctionComponent<PathsListProps> = ({
 }) => {
 
   const [selectedPaths, setSelectedPaths] = useState<Path[]>(selected);
-  const { data } = useQuery<{ unjoinedPaths: Path[] }>(getPaths);
+  const { data } = useQuery<{ getMyUnjoinedPaths: Path[] }>(getPaths);
   const path = data?.getMyUnjoinedPaths;
 
   useEffect(() => {

--- a/packages/client/src/components/PathsList/PathsList.tsx
+++ b/packages/client/src/components/PathsList/PathsList.tsx
@@ -10,7 +10,7 @@ import styles from './PathsList.module.css';
 export type SelectedPath = Pick<Path, 'id'>;
 
 const getPaths = gql`{
-  getMyUnjoinedPaths {
+  myUnjoinedPaths {
     id
     name
     icon
@@ -29,8 +29,8 @@ export const PathsList: React.FunctionComponent<PathsListProps> = ({
 }) => {
 
   const [selectedPaths, setSelectedPaths] = useState<Path[]>(selected);
-  const { data } = useQuery<{ getMyUnjoinedPaths: Path[] }>(getPaths);
-  const path = data?.getMyUnjoinedPaths;
+  const { data } = useQuery<{ myUnjoinedPaths: Path[] }>(getPaths);
+  const path = data?.myUnjoinedPaths;
 
   useEffect(() => {
     if (onChange) onChange(selectedPaths);


### PR DESCRIPTION
## Fixed issues (PRs without this will not be accepted)
- Fixes #154 

## Changes
- Creates a new path query (myUnjoinedPaths)
- The new query returns all paths the user hasn't joined yet
- The pathlist component now uses this query and only returns paths the user hasn't joined yet within the join path modal


## PR Checklist
- [x] Does your PR contain relevant tests that pass?
- [x] Is your code linted? `yarn lint` or `yarn lint:fix`
- [x] Does your code build correctly in ALL projects? `yarn build`
