### PR TITLE
(fix/client): removing sign out button fixed the layout of the app header

### DIFF
--- a/packages/client/src/components/AppHeader/AppHeader.tsx
+++ b/packages/client/src/components/AppHeader/AppHeader.tsx
@@ -5,7 +5,6 @@ import { Icon, PathIcon } from '@codement/ui';
 import LogoMark from '@codement/ui/images/logo-mark.svg';
 import { DropdownMenu } from '../DropdownMenu/DropdownMenu';
 import styles from './AppHeader.module.css';
-import { SignOutBtn } from '../SignOutBtn/SignOutBtn';
 
 // TODO: Replace user profile picture when #27 is completed.
 // TODO: Replace the class icon with the actual class the student is
@@ -42,7 +41,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({ minimal }) => {
         </Link>
       </div>}
 
-      <SignOutBtn />
+      {/* <SignOutBtn /> */}
 
       <div className="inline font-semibold float-right mr-1 sm:mr-16">
         {!minimal && <PathIcon

--- a/packages/client/src/components/SignOutBtn/SignOutBtn.tsx
+++ b/packages/client/src/components/SignOutBtn/SignOutBtn.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-
-import { Button } from '../../../../ui/components/Button/Button';
-
-export const SignOutBtn = () => (
-  <Button btnType="primary" size="large">
-    Sign out
-  </Button>
-);


### PR DESCRIPTION
Fixed issues
- Fixes #236 

## Changes
- Removed all references to Sign Out button 
- Removed Sign Out component itself as its no longer used. Logout is being used instead

![image](https://user-images.githubusercontent.com/8683116/85491885-48448180-b5a2-11ea-947b-55dc0480ec5d.png)
